### PR TITLE
Replace LAWKIT_DEBUG environment variable with --verbose CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "lawkit"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "lawkit-core"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "calamine",

--- a/lawkit-cli/src/subcommands/normal.rs
+++ b/lawkit-cli/src/subcommands/normal.rs
@@ -64,13 +64,13 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         }
     } else {
         // stdin入力の場合：ストリーミング処理を使用
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!("Debug: Reading from stdin, using automatic optimization");
         }
 
         let mut reader = OptimizedFileReader::from_stdin();
 
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!(
                 "Debug: Using automatic optimization (streaming + incremental + memory efficiency)"
             );
@@ -81,7 +81,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         {
             Ok(nested_numbers) => {
                 let flattened: Vec<f64> = nested_numbers.into_iter().flatten().collect();
-                if std::env::var("LAWKIT_DEBUG").is_ok() {
+                if matches.get_flag("verbose") {
                     eprintln!("Debug: Collected {} numbers from stream", flattened.len());
                 }
                 flattened
@@ -103,7 +103,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
             let chunk_result = match streaming_normal_analysis(numbers.into_iter(), &memory_config)
             {
                 Ok(result) => {
-                    if std::env::var("LAWKIT_DEBUG").is_ok() {
+                    if matches.get_flag("verbose") {
                         eprintln!(
                             "Debug: Streaming analysis successful - {} items processed",
                             result.total_items
@@ -117,7 +117,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
                 }
             };
 
-            if std::env::var("LAWKIT_DEBUG").is_ok() {
+            if matches.get_flag("verbose") {
                 eprintln!(
                     "Debug: Processed {} numbers in {} chunks",
                     chunk_result.total_items, chunk_result.chunks_processed

--- a/lawkit-cli/src/subcommands/pareto.rs
+++ b/lawkit-cli/src/subcommands/pareto.rs
@@ -15,7 +15,7 @@ use lawkit_core::{
 
 pub fn run(matches: &ArgMatches) -> Result<()> {
     // Determine input source based on arguments
-    if std::env::var("LAWKIT_DEBUG").is_ok() {
+    if matches.get_flag("verbose") {
         eprintln!(
             "Debug: input argument = {:?}",
             matches.get_one::<String>("input")
@@ -52,14 +52,14 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         }
     } else {
         // Read from stdin - use automatic optimization based on data characteristics
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!("Debug: Reading from stdin, using automatic optimization");
         }
 
         // 自動最適化処理：データ特性に基づいてストリーミング処理を自動選択
         let mut reader = OptimizedFileReader::from_stdin();
 
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!(
                 "Debug: Using automatic optimization (streaming + incremental + memory efficiency)"
             );
@@ -67,14 +67,14 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
 
         // ストリーミング処理でインクリメンタル分析を実行
         let numbers = match reader.read_lines_streaming(|line: String| {
-            if std::env::var("LAWKIT_DEBUG").is_ok() {
+            if matches.get_flag("verbose") {
                 eprintln!("Debug: Processing line: '{line}'");
             }
             parse_text_input(&line).map(Some).or(Ok(None))
         }) {
             Ok(nested_numbers) => {
                 let flattened: Vec<f64> = nested_numbers.into_iter().flatten().collect();
-                if std::env::var("LAWKIT_DEBUG").is_ok() {
+                if matches.get_flag("verbose") {
                     eprintln!("Debug: Collected {} numbers from stream", flattened.len());
                 }
                 flattened
@@ -96,7 +96,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         // インクリメンタルストリーミング分析を実行
         let chunk_result = match streaming_pareto_analysis(numbers.into_iter(), &memory_config) {
             Ok(result) => {
-                if std::env::var("LAWKIT_DEBUG").is_ok() {
+                if matches.get_flag("verbose") {
                     eprintln!(
                         "Debug: Streaming analysis successful - {} items processed",
                         result.total_items
@@ -110,7 +110,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
             }
         };
 
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!(
                 "Debug: Processed {} numbers in {} chunks",
                 chunk_result.total_items, chunk_result.chunks_processed

--- a/lawkit-cli/src/subcommands/poisson.rs
+++ b/lawkit-cli/src/subcommands/poisson.rs
@@ -55,13 +55,13 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         }
     } else {
         // stdin入力の場合：ストリーミング処理を使用
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!("Debug: Reading from stdin, using automatic optimization");
         }
 
         let mut reader = OptimizedFileReader::from_stdin();
 
-        if std::env::var("LAWKIT_DEBUG").is_ok() {
+        if matches.get_flag("verbose") {
             eprintln!(
                 "Debug: Using automatic optimization (streaming + incremental + memory efficiency)"
             );
@@ -72,7 +72,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
         {
             Ok(nested_numbers) => {
                 let flattened: Vec<f64> = nested_numbers.into_iter().flatten().collect();
-                if std::env::var("LAWKIT_DEBUG").is_ok() {
+                if matches.get_flag("verbose") {
                     eprintln!("Debug: Collected {} numbers from stream", flattened.len());
                 }
                 flattened
@@ -100,7 +100,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
             let chunk_result =
                 match streaming_poisson_analysis(event_counts.into_iter(), &memory_config) {
                     Ok(result) => {
-                        if std::env::var("LAWKIT_DEBUG").is_ok() {
+                        if matches.get_flag("verbose") {
                             eprintln!(
                                 "Debug: Streaming analysis successful - {} items processed",
                                 result.total_items
@@ -114,7 +114,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
                     }
                 };
 
-            if std::env::var("LAWKIT_DEBUG").is_ok() {
+            if matches.get_flag("verbose") {
                 eprintln!(
                     "Debug: Processed {} numbers in {} chunks",
                     chunk_result.total_items, chunk_result.chunks_processed

--- a/lawkit-cli/tests/optimization_threshold_tests.rs
+++ b/lawkit-cli/tests/optimization_threshold_tests.rs
@@ -122,7 +122,8 @@ fn test_memory_efficiency_large_dataset() {
 fn run_lawkit_command_with_debug(subcommand: &str, args: &[&str]) -> std::process::Output {
     let mut command = Command::new("cargo");
     command.args(["run", "--bin", "lawkit", "--", subcommand]);
-    command.env("LAWKIT_DEBUG", "1"); // Enable debug output
+    // Enable verbose output for debugging
+    command.args(["--verbose"]); // Enable debug output
 
     // Handle test data similar to integration tests
     let mut test_data = String::new();

--- a/scripts/setup-github-workflow.sh
+++ b/scripts/setup-github-workflow.sh
@@ -55,116 +55,53 @@ else
 fi
 
 echo ""
-echo "🔒 Step 2: Branch Protection (DISABLED)"
-echo "--------------------------------------"
-echo "⚠️  Branch protection is intentionally disabled for fast development"
-echo "   Direct pushes to main are allowed for urgent situations"
-echo "   This prioritizes development speed over process enforcement"
-REPO_FULL_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-if gh api "repos/$REPO_FULL_NAME/branches/main/protection" --method DELETE > /dev/null 2>&1; then
-    echo "✅ Branch protection removed successfully"
-else
-    echo "ℹ️  No branch protection to remove (already disabled)"
-fi
-
-echo ""
-echo "🏗️ Step 3: Configuring Repository Settings" 
+echo "🔧 Step 2: Configuring Repository Settings" 
 echo "------------------------------------------"
-echo "Setting up automatic branch deletion and other repository settings..."
+echo "Setting up auto-merge, branch deletion, and merge options..."
 REPO_FULL_NAME=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-# Enable automatic branch deletion after PR merge
-if gh api "repos/$REPO_FULL_NAME" --method PATCH --field delete_branch_on_merge=true > /dev/null 2>&1; then
-    echo "✅ Automatic branch deletion enabled"
-else
-    echo "❌ Failed to enable automatic branch deletion"
-fi
-
-# Enable other useful settings
+# Enable auto-merge and automatic branch deletion
 if gh api "repos/$REPO_FULL_NAME" --method PATCH \
+    --field allow_auto_merge=true \
+    --field delete_branch_on_merge=true \
     --field allow_squash_merge=true \
     --field allow_merge_commit=true \
-    --field allow_rebase_merge=true \
-    --field allow_auto_merge=false > /dev/null 2>&1; then
-    echo "✅ Merge options configured"
+    --field allow_rebase_merge=true > /dev/null 2>&1; then
+    echo "✅ Repository settings configured:"
+    echo "   - Auto-merge enabled (for solo development)"
+    echo "   - Automatic branch deletion after merge"
+    echo "   - All merge types enabled (merge, squash, rebase)"
 else
-    echo "❌ Failed to configure merge options"
+    echo "❌ Failed to configure repository settings"
 fi
+
 
 echo ""
-echo "🔧 Step 4: Git Hooks (DISABLED)"
-echo "-------------------------------"
-echo "⚠️  Pre-push hooks are intentionally disabled"
-echo "   Pushes should be fast and unrestricted when urgent"
-echo "   Validation can be run manually with: ./scripts/ci-local.sh"
-if git config core.hooksPath | grep -q ".githooks"; then
-    git config --unset core.hooksPath
-    echo "✅ Git hooks disabled successfully"
-else
-    echo "ℹ️  Git hooks already disabled"
-fi
-
-echo ""
-echo "📚 Step 5: Validation and Testing"
-echo "---------------------------------"
-echo "Testing simplified workflow setup..."
-
-# Test if branch protection is disabled (as intended)
-if gh api "repos/$REPO_FULL_NAME/branches/main/protection" > /dev/null 2>&1; then
-    echo "⚠️  Branch protection is still active (should be disabled)"
-else
-    echo "✅ Branch protection is disabled (as intended)"
-fi
-
-# Test if labels were created
-if [ "$SKIP_LABELS" != "true" ]; then
-    LABEL_COUNT=$(gh label list --json name | jq '. | length' 2>/dev/null || echo "0")
-    if [ "$LABEL_COUNT" -gt 15 ]; then
-        echo "✅ Labels created successfully ($LABEL_COUNT labels found)"
-    else
-        echo "⚠️  Limited labels found ($LABEL_COUNT labels)"
-    fi
-fi
-
-# Test if git hooks are disabled (as intended)
-if git config core.hooksPath | grep -q ".githooks"; then
-    echo "⚠️  Git hooks are still active (should be disabled)"
-else
-    echo "✅ Git hooks are disabled (as intended)"
-fi
-
-echo ""
-echo "🎯 Step 6: Workflow Summary"
+echo "🎯 Step 3: Workflow Summary"
 echo "---------------------------"
-echo "Simplified GitHub Workflow is now configured with the following features:"
+echo "GitHub Workflow is now configured with the following features:"
 echo ""
-echo "✅ Repository Settings:"
+echo "✅ Solo Development Features:"
+echo "   - Auto-merge enabled (no review required for owner)"
 echo "   - Automatic branch deletion after merge"
-echo "   - All merge types enabled (merge, squash, rebase)"
-echo "   - Structured labels for issue management"
+echo "   - All merge types available"
 echo ""
-echo "⚠️  Intentionally Disabled (for fast development):"
-echo "   - Branch protection (direct push to main allowed)"
-echo "   - Pre-push hooks (no validation blocking pushes)"
-echo "   - PR review requirements (optional)"
+echo "📋 Recommended Development Workflow:"
+echo "1. Create feature branch: git checkout -b feature/name"
+echo "2. Make changes and commit: git commit -m \"...\""
+echo "3. Push branch: git push -u origin feature/name"
+echo "4. Create PR: gh pr create --title \"...\" --body \"...\""
+echo "5. Auto-merge: gh pr merge --auto --squash"
+echo "6. CI will automatically merge after tests pass"
 echo ""
-echo "📋 Simplified Development Workflow:"
-echo "1. Option A - Direct to main: git push origin main (fast, for urgent fixes)"
-echo "2. Option B - Feature branch: git checkout -b feature/name && git push && gh pr create"
-echo "3. Manual validation: ./scripts/ci-local.sh (run when convenient)"
-echo "4. CI/CD runs automatically on push (but doesn't block merges)"
+echo "🔧 Quick Commands:"
+echo "   ./scripts/create-pr.sh \"Title\" \"Description\" - Create PR with auto-merge"
+echo "   ./scripts/ci-local.sh - Run local CI validation"
 echo ""
-echo "🔧 Philosophy:"
-echo "   - Prioritize development speed over process enforcement"
-echo "   - Allow unrestricted pushes when urgent"
-echo "   - Optional validation rather than mandatory blocks"
-echo "   - Developers can choose their workflow based on urgency"
-
+echo "🎉 GitHub Workflow setup completed successfully!"
 echo ""
-echo "🎉 Simplified GitHub Workflow setup completed successfully!"
-echo ""
-echo "Your repository is now ready for fast, flexible development with:"
-echo "- Unrestricted push access"
-echo "- Optional quality checks"
-echo "- Structured issue management"
-echo "- Flexible CI/CD integration"
+echo "Your repository is ready for efficient solo development with:"
+echo "- Streamlined PR workflow"
+echo "- Automatic quality checks"
+echo "- Clean branch management"
+echo "- Future contributor readiness"

--- a/tests/integration/automatic_optimization_tests.rs
+++ b/tests/integration/automatic_optimization_tests.rs
@@ -11,7 +11,8 @@ mod automatic_optimization_tests {
         let mut command = Command::new("cargo");
         command.args(["run", "--bin", "lawkit", "--", subcommand]);
         command.args(args);
-        command.env("LAWKIT_DEBUG", "1");
+        // Enable verbose output for debugging
+        command.args(["--verbose"]);
         command.env("LANG", "en_US.UTF-8");
 
         if let Some(data) = input_data {


### PR DESCRIPTION
## Summary
Replace custom LAWKIT_DEBUG environment variable with explicit --verbose CLI flag to follow UNIX philosophy.

## Changes
- ✅ Removed LAWKIT_DEBUG environment variable checks from all source files
- ✅ Replaced with `matches.get_flag("verbose")` calls using existing --verbose option  
- ✅ Updated test files to use --verbose flag instead of environment variable
- ✅ Kept NO_COLOR/FORCE_COLOR (widely adopted terminal standards)
- ✅ Updated GitHub workflow setup script for auto-merge support

## Rationale
UNIX philosophy: explicit is better than implicit. Configuration should be via arguments/options, not hidden environment variables.

The --verbose flag (with -v shorthand) already exists in common_options.rs, so this migrates existing debug functionality to use the standard verbose flag.

## Testing
- Environment variable checks completely removed from codebase
- Debug output now controlled by explicit --verbose/-v flag
- Tests updated to use new flag approach

Resolves #2